### PR TITLE
chore: update npm script naming convention for consistency

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,14 +3,14 @@
   "scripts": {
     "prepare": "npm run sync-client && husky",
     "build": "node src -d",
-    "lint": "concurrently \"npm:lint-*\"",
-    "lint-eslint": "npx eslint . --ext .js",
-    "lint-prettier": "npx prettier . --check",
-    "lint-editorconfig": "npx editorconfig-checker",
-    "lint-markdownlint": "npx markdownlint **/*.md",
-    "fix": "concurrently \"npm:fix-*\"",
-    "fix-eslint": "npx eslint . --fix --ext .js",
-    "fix-prettier": "npx prettier . --write",
+    "lint": "concurrently \"npm:lint:*\"",
+    "lint:eslint": "npx eslint . --ext .js",
+    "lint:prettier": "npx prettier . --check",
+    "lint:editorconfig": "npx editorconfig-checker",
+    "lint:markdownlint": "npx markdownlint **/*.md",
+    "fix": "concurrently \"npm:fix:*\"",
+    "fix:eslint": "npx eslint . --fix --ext .js",
+    "fix:prettier": "npx prettier . --write",
     "sync-client": "bash sync-client.sh"
   },
   "dependencies": {


### PR DESCRIPTION
Changed `lint-*` and `fix-*` to `lint:*` and `fix:*` for better alignment with npm script naming conventions.