### PR TITLE
chore: detach `lint-staged` related configs from `package.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,5 @@ node_modules
 .prettierignore
 .prettierrc.js
 .textlintrc.js
+lint-staged.config.js
 VScode.code-workspace

--- a/package.json
+++ b/package.json
@@ -30,16 +30,5 @@
     "prettier": "^3.4.2",
     "textlint": "^14.4.0",
     "textlint-rule-allowed-uris": "^1.0.6"
-  },
-  "lint-staged": {
-    "*": [
-      "npx prettier --check",
-      "npx editorconfig-checker"
-    ],
-    "*.js": "npx eslint",
-    "*.md": [
-      "npx markdownlint",
-      "npx textlint -f pretty-error"
-    ]
   }
 }

--- a/sync-client.sh
+++ b/sync-client.sh
@@ -20,4 +20,5 @@ cp configs/.nvmrc .
 cp configs/.prettierignore .
 cp configs/.prettierrc.js .
 cp configs/.textlintrc.js .
+cp configs/lint-staged.config.js .
 cp configs/VScode.code-workspace .


### PR DESCRIPTION
This pull request includes changes to the `package.json` and `sync-client.sh` files. The most important changes involve the removal of the `lint-staged` configuration from `package.json` and the addition of a new configuration file in the synchronization script.

Configuration updates:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L33-L43): Removed the `lint-staged` configuration section which included commands for `prettier`, `editorconfig-checker`, `eslint`, `markdownlint`, and `textlint`.

Synchronization script updates:

* [`sync-client.sh`](diffhunk://#diff-9f218442f37688e98d9dcaf1702d0954aaaabd45dbc04456c4a900bf0f9a24a2R23): Added a command to copy `configs/lint-staged.config.js` to the current directory.