### PR TITLE
chore: remove `.nyc_output` from ignore lists of configs

### DIFF
--- a/configs/.clang-format-ignore
+++ b/configs/.clang-format-ignore
@@ -11,5 +11,4 @@ build
 .env.production
 
 # tests
-.nyc_output
 coverage

--- a/configs/.gitignore
+++ b/configs/.gitignore
@@ -11,7 +11,6 @@ build
 .env.production
 
 # tests
-.nyc_output
 coverage
 
 # packages

--- a/configs/.prettierignore
+++ b/configs/.prettierignore
@@ -11,7 +11,6 @@ build
 .env.production
 
 # tests
-.nyc_output
 coverage
 
 # package


### PR DESCRIPTION
This pull request includes changes to the `.clang-format-ignore`, `.gitignore`, and `.prettierignore` files to improve the build configuration by removing unnecessary entries.

Build configuration improvements:

* [`configs/.clang-format-ignore`](diffhunk://#diff-04870cd9c1d71af0e1764938c34398aa71653548f32ff618a570e22580857384L14): Removed the `.nyc_output` entry from the ignore list.
* [`configs/.gitignore`](diffhunk://#diff-127fa2a18fcf6528a15cc22b53c70b0ddd7036ad856b76fa26f00468eea2af3dL14): Removed the `.nyc_output` entry from the ignore list.
* [`configs/.prettierignore`](diffhunk://#diff-65e906ab3cea5b94ff5b7b16ce6b39dc57c1ffb7a5ce603f12b94a571b3fc545L14): Removed the `.nyc_output` entry from the ignore list.