### PR TITLE
chore(deps): update dependabot configuration and add `engines` field to `package.json`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,23 +2,46 @@ version: 2
 updates:
   # Maintain dependencies for npm.
   - package-ecosystem: 'npm'
+    assignees:
+      - 'lumirlumir'
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
-    ignore:
-      - dependency-name: 'eslint'
-        versions: ['9']
+    groups:
+      bananass:
+        patterns:
+          - 'eslint-config-bananass'
+          - 'eslint-config-bananass-react'
+          - 'prettier-config-bananass'
+      babel:
+        patterns:
+          - '@babel/*'
+      react:
+        patterns:
+          - 'react'
+          - 'react-dom'
+      next:
+        patterns:
+          - 'next'
+          - '@next/*'
+    reviewers:
+      - 'lumirlumir'
     schedule:
       interval: 'daily'
       time: '10:00'
       timezone: 'Asia/Seoul'
     pull-request-branch-name:
       separator: '-'
+    versioning-strategy: 'increase'
 
   # Maintain dependencies for GitHub Actions.
   - package-ecosystem: 'github-actions'
+    assignees:
+      - 'lumirlumir'
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
+    reviewers:
+      - 'lumirlumir'
     schedule:
       interval: 'weekly'
       day: 'monday'

--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "private": true,
   "packageManager": "npm@10.9.2",
+  "engines": {
+    "node": ">=20.18.0"
+  },
   "scripts": {
     "prepare": "npm run sync-client && husky",
     "build": "node src -d",


### PR DESCRIPTION
This pull request includes changes to the `.github/dependabot.yml` configuration file and the `package.json` file to improve dependency management and ensure compatibility with specific Node.js versions. The most important changes include adding assignees and reviewers for dependency updates, organizing dependencies into groups, and specifying the required Node.js version.

Dependency management improvements:

* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R5-R44): Added `assignees` and `reviewers` fields to assign and review dependency updates.
* [`.github/dependabot.yml`](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R5-R44): Organized dependencies into groups (`bananass`, `babel`, `react`, `next`) to better manage specific sets of dependencies.

Compatibility enhancements:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R4-R6): Added an `engines` field to specify the required Node.js version (`>=20.18.0`).