### PR TITLE
ci(*): update `lint` workflow with permissions and concurrency settings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,13 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ !contains(github.ref, 'main') }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes updates to the GitHub Actions workflow configuration to enhance permissions and concurrency management.

Enhancements to GitHub Actions workflow:

* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R10-R16): Added `permissions` to set contents to read-only.
* [`.github/workflows/lint.yml`](diffhunk://#diff-107e910e9f2ebfb9a741fa10b2aa7100cc1fc4f5f3aca2dfe78b905cbd73c0d2R10-R16): Introduced `concurrency` to group workflows by name and ref, and to cancel in-progress runs for non-main branches.