### PR TITLE
ci(*): update permissions for `sync-server` workflow

### DIFF
--- a/.github/workflows/sync-server.yml
+++ b/.github/workflows/sync-server.yml
@@ -7,6 +7,9 @@ on:
     branches: [main]
     paths: ['clients/**', 'configs/**']
 
+permissions:
+  contents: read
+
 jobs:
   sync-server:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/sync-server.yml` file to adjust permissions for the sync-server job. The change grants read permissions to contents. 

* [`.github/workflows/sync-server.yml`](diffhunk://#diff-842863ee6b541e0b5c2c7502700516d0d034a64dd522271d80ef47aba6fc2fc2R10-R12): Added `permissions` section to grant read permissions to contents.