### PR TITLE
chore(*): update lint configs and bump package versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,8 @@ node_modules
 .markdownlintignore
 .nvmrc
 .prettierignore
-.prettierrc.cjs
 .textlintrc.cjs
 VScode.code-workspace
 eslint.config.mjs
 lint-staged.config.mjs
+prettier.config.mjs

--- a/configs/.prettierrc.cjs
+++ b/configs/.prettierrc.cjs
@@ -1,1 +1,0 @@
-module.exports = require('prettier-config-bananass');

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,13 +11,13 @@
         "concurrently": "^9.1.2",
         "editorconfig-checker": "^6.0.1",
         "eslint": "^9.24.0",
-        "eslint-config-bananass": "^0.0.7",
+        "eslint-config-bananass": "^0.1.0-canary.2",
         "eslint-plugin-mark": "^0.1.0-canary.1",
         "husky": "^9.1.7",
         "lint-staged": "^15.5.1",
         "markdownlint-cli": "^0.44.0",
         "prettier": "^3.5.3",
-        "prettier-config-bananass": "^0.0.1",
+        "prettier-config-bananass": "^0.1.0-canary.2",
         "textlint": "^14.6.0",
         "textlint-rule-allowed-uris": "^1.1.0"
       },
@@ -1230,9 +1230,9 @@
       }
     },
     "node_modules/@next/eslint-plugin-next": {
-      "version": "15.2.4",
-      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.2.4.tgz",
-      "integrity": "sha512-O8ScvKtnxkp8kL9TpJTTKnMqlkZnS+QxwoQnJwPGBxjBbzd6OVVPEJ5/pMNrktSyXQD/chEfzfFzYLM6JANOOQ==",
+      "version": "15.3.0",
+      "resolved": "https://registry.npmjs.org/@next/eslint-plugin-next/-/eslint-plugin-next-15.3.0.tgz",
+      "integrity": "sha512-511UUcpWw5GWTyKfzW58U2F/bYJyjLE9e3SlnGK/zSXq7RqLlqFO8B9bitJjumLpj317fycC96KZ2RZsjGNfBw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1295,9 +1295,9 @@
       "dev": true
     },
     "node_modules/@stylistic/eslint-plugin-js": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-3.1.0.tgz",
-      "integrity": "sha512-lQktsOiCr8S6StG29C5fzXYxLOD6ID1rp4j6TRS+E/qY1xd59Fm7dy5qm9UauJIEoSTlYx6yGsCHYh5UkgXPyg==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-js/-/eslint-plugin-js-4.2.0.tgz",
+      "integrity": "sha512-MiJr6wvyzMYl/wElmj8Jns8zH7Q1w8XoVtm+WM6yDaTrfxryMyb8n0CMxt82fo42RoLIfxAEtM6tmQVxqhk0/A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1308,7 +1308,7 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "peerDependencies": {
-        "eslint": ">=8.40.0"
+        "eslint": ">=9.0.0"
       }
     },
     "node_modules/@stylistic/eslint-plugin-js/node_modules/eslint-visitor-keys": {
@@ -1676,17 +1676,17 @@
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.29.0.tgz",
-      "integrity": "sha512-PAIpk/U7NIS6H7TEtN45SPGLQaHNgB7wSjsQV/8+KYokAb2T/gloOA/Bee2yd4/yKVhPKe5LlaUGhAZk5zmSaQ==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.30.1.tgz",
+      "integrity": "sha512-v+VWphxMjn+1t48/jO4t950D6KR8JaJuNXzi33Ve6P8sEmPr5k6CEXjdGwT6+LodVnEa91EQCtwjWNUCPweo+Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.10.0",
-        "@typescript-eslint/scope-manager": "8.29.0",
-        "@typescript-eslint/type-utils": "8.29.0",
-        "@typescript-eslint/utils": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0",
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/type-utils": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "graphemer": "^1.4.0",
         "ignore": "^5.3.1",
         "natural-compare": "^1.4.0",
@@ -1706,16 +1706,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.29.0.tgz",
-      "integrity": "sha512-8C0+jlNJOwQso2GapCVWWfW/rzaq7Lbme+vGUFKE31djwNncIpgXD7Cd4weEsDdkoZDjH0lwwr3QDQFuyrMg9g==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.30.1.tgz",
+      "integrity": "sha512-H+vqmWwT5xoNrXqWs/fesmssOW70gxFlgcMlYcBaWNPIEWDgLa4W9nkSPmhuOgLnXq9QYgkZ31fhDyLhleCsAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.29.0",
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/typescript-estree": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0",
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/typescript-estree": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "debug": "^4.3.4"
       },
       "engines": {
@@ -1731,14 +1731,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.29.0.tgz",
-      "integrity": "sha512-aO1PVsq7Gm+tcghabUpzEnVSFMCU4/nYIgC2GOatJcllvWfnhrgW0ZEbnTxm36QsikmCN1K/6ZgM7fok2I7xNw==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.30.1.tgz",
+      "integrity": "sha512-+C0B6ChFXZkuaNDl73FJxRYT0G7ufVPOSQkqkpM/U198wUwUFOtgo1k/QzFh1KjpBitaK7R1tgjVz6o9HmsRPg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0"
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1749,14 +1749,14 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.29.0.tgz",
-      "integrity": "sha512-ahaWQ42JAOx+NKEf5++WC/ua17q5l+j1GFrbbpVKzFL/tKVc0aYY8rVSYUpUvt2hUP1YBr7mwXzx+E/DfUWI9Q==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.30.1.tgz",
+      "integrity": "sha512-64uBF76bfQiJyHgZISC7vcNz3adqQKIccVoKubyQcOnNcdJBvYOILV1v22Qhsw3tw3VQu5ll8ND6hycgAR5fEA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/typescript-estree": "8.29.0",
-        "@typescript-eslint/utils": "8.29.0",
+        "@typescript-eslint/typescript-estree": "8.30.1",
+        "@typescript-eslint/utils": "8.30.1",
         "debug": "^4.3.4",
         "ts-api-utils": "^2.0.1"
       },
@@ -1773,9 +1773,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.29.0.tgz",
-      "integrity": "sha512-wcJL/+cOXV+RE3gjCyl/V2G877+2faqvlgtso/ZRbTCnZazh0gXhe+7gbAnfubzN2bNsBtZjDvlh7ero8uIbzg==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.30.1.tgz",
+      "integrity": "sha512-81KawPfkuulyWo5QdyG/LOKbspyyiW+p4vpn4bYO7DM/hZImlVnFwrpCTnmNMOt8CvLRr5ojI9nU1Ekpw4RcEw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1787,14 +1787,14 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.29.0.tgz",
-      "integrity": "sha512-yOfen3jE9ISZR/hHpU/bmNvTtBW1NjRbkSFdZOksL1N+ybPEE7UVGMwqvS6CP022Rp00Sb0tdiIkhSCe6NI8ow==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.30.1.tgz",
+      "integrity": "sha512-kQQnxymiUy9tTb1F2uep9W6aBiYODgq5EMSk6Nxh4Z+BDUoYUSa029ISs5zTzKBFnexQEh71KqwjKnRz58lusQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/visitor-keys": "8.29.0",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/visitor-keys": "8.30.1",
         "debug": "^4.3.4",
         "fast-glob": "^3.3.2",
         "is-glob": "^4.0.3",
@@ -1870,16 +1870,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.29.0.tgz",
-      "integrity": "sha512-gX/A0Mz9Bskm8avSWFcK0gP7cZpbY4AIo6B0hWYFCaIsz750oaiWR4Jr2CI+PQhfW1CpcQr9OlfPS+kMFegjXA==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.30.1.tgz",
+      "integrity": "sha512-T/8q4R9En2tcEsWPQgB5BQ0XJVOtfARcUvOa8yJP3fh9M/mXraLxZrkCfGb6ChrO/V3W+Xbd04RacUEqk1CFEQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.4.0",
-        "@typescript-eslint/scope-manager": "8.29.0",
-        "@typescript-eslint/types": "8.29.0",
-        "@typescript-eslint/typescript-estree": "8.29.0"
+        "@typescript-eslint/scope-manager": "8.30.1",
+        "@typescript-eslint/types": "8.30.1",
+        "@typescript-eslint/typescript-estree": "8.30.1"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1894,13 +1894,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.29.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.29.0.tgz",
-      "integrity": "sha512-Sne/pVz8ryR03NFK21VpN88dZ2FdQXOlq3VIklbrTYEt8yXtRFr9tvUhqvCeKjqYk5FSim37sHbooT6vzBTZcg==",
+      "version": "8.30.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.30.1.tgz",
+      "integrity": "sha512-aEhgas7aJ6vZnNFC7K4/vMGDGyOiqWcYZPpIWrTKuTAlsvDNKy2GFDqh9smL+iq069ZvR0YzEeq0B8NJlLzjFA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.29.0",
+        "@typescript-eslint/types": "8.30.1",
         "eslint-visitor-keys": "^4.2.0"
       },
       "engines": {
@@ -2430,14 +2430,14 @@
       }
     },
     "node_modules/call-bound": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
-      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
-        "get-intrinsic": "^1.2.6"
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
       },
       "engines": {
         "node": ">= 0.4"
@@ -3365,9 +3365,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.0.0.tgz",
-      "integrity": "sha512-MZ4iQ6JwHOBQjahnjwaC1ZtIBH+2ohjamzAO3oaHcXYup7qxjF2fixyH+Q71voWHeOkI2q/TnJao/KfXYIZWbw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3535,20 +3535,20 @@
       }
     },
     "node_modules/eslint-config-bananass": {
-      "version": "0.0.7",
-      "resolved": "https://registry.npmjs.org/eslint-config-bananass/-/eslint-config-bananass-0.0.7.tgz",
-      "integrity": "sha512-YIS44XYasO18y8JEPXRBZ/1glLAsQoDCGphPbxF5g34HsNjEq3t78O64JVUHlzcSRMZxqsletmAJByFVXREJAA==",
+      "version": "0.1.0-canary.2",
+      "resolved": "https://registry.npmjs.org/eslint-config-bananass/-/eslint-config-bananass-0.1.0-canary.2.tgz",
+      "integrity": "sha512-6VYYZe+E0BMz7Ge2sBhuySUbIGnpVeO0Fa/KGkVKroW+d18GemEjrcwa4E+dIqYiVejRbQHsFelqG3XeGlZUtA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@next/eslint-plugin-next": "^15.2.4",
-        "@stylistic/eslint-plugin-js": "^3.1.0",
-        "@typescript-eslint/eslint-plugin": "^8.29.0",
-        "@typescript-eslint/parser": "^8.29.0",
+        "@next/eslint-plugin-next": "^15.3.0",
+        "@stylistic/eslint-plugin-js": "^4.2.0",
+        "@typescript-eslint/eslint-plugin": "^8.29.1",
+        "@typescript-eslint/parser": "^8.29.1",
         "eslint-plugin-import": "^2.31.0",
         "eslint-plugin-jsx-a11y": "^6.10.2",
         "eslint-plugin-n": "^17.17.0",
-        "eslint-plugin-react": "^7.37.4",
+        "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-compiler": "^19.0.0-beta-714736e-20250131",
         "eslint-plugin-react-hooks": "^5.2.0",
         "globals": "^16.0.0"
@@ -3825,9 +3825,9 @@
       }
     },
     "node_modules/eslint-plugin-react": {
-      "version": "7.37.4",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.4.tgz",
-      "integrity": "sha512-BGP0jRmfYyvOyvMoRX/uoUeW+GqNj9y16bPQzqAHf3AYII/tDs+jMN0dBVkl88/OZwNGwrVFxE7riHsXVfy/LQ==",
+      "version": "7.37.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.5.tgz",
+      "integrity": "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3841,7 +3841,7 @@
         "hasown": "^2.0.2",
         "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "minimatch": "^3.1.2",
-        "object.entries": "^1.1.8",
+        "object.entries": "^1.1.9",
         "object.fromentries": "^2.0.8",
         "object.values": "^1.2.1",
         "prop-types": "^15.8.1",
@@ -4360,18 +4360,18 @@
       }
     },
     "node_modules/get-intrinsic": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
-      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind-apply-helpers": "^1.0.1",
+        "call-bind-apply-helpers": "^1.0.2",
         "es-define-property": "^1.0.1",
         "es-errors": "^1.3.0",
-        "es-object-atoms": "^1.0.0",
+        "es-object-atoms": "^1.1.1",
         "function-bind": "^1.1.2",
-        "get-proto": "^1.0.0",
+        "get-proto": "^1.0.1",
         "gopd": "^1.2.0",
         "has-symbols": "^1.1.0",
         "hasown": "^2.0.2",
@@ -7393,15 +7393,16 @@
       }
     },
     "node_modules/object.entries": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.8.tgz",
-      "integrity": "sha512-cmopxi8VwRIAw/fkijJohSfpef5PdN0pMQJN6VC/ZKvn0LIknWD8KtgY6KlQdEc4tIjcQ3HxSMmnvtzIscdaYQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.9.tgz",
+      "integrity": "sha512-8u/hfXFRBD1O0hPUjioLhoWFHRmt6tKA4/vZPyckBr18l1KE9uHrFaFaUi8MDRTpi4uak2goyPTSNJLXX2k2Hw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "call-bind": "^1.0.7",
+        "call-bind": "^1.0.8",
+        "call-bound": "^1.0.4",
         "define-properties": "^1.2.1",
-        "es-object-atoms": "^1.0.0"
+        "es-object-atoms": "^1.1.1"
       },
       "engines": {
         "node": ">= 0.4"
@@ -7821,13 +7822,13 @@
       }
     },
     "node_modules/prettier-config-bananass": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/prettier-config-bananass/-/prettier-config-bananass-0.0.1.tgz",
-      "integrity": "sha512-hzCBcHUL4wAtyzsfyo2BqTQz7t1sPa9u2Rgm5r6kF+ZE/LfyK+POAF9Wt6Hh8ojca21iNMxmP8Si2dt205RtVQ==",
+      "version": "0.1.0-canary.2",
+      "resolved": "https://registry.npmjs.org/prettier-config-bananass/-/prettier-config-bananass-0.1.0-canary.2.tgz",
+      "integrity": "sha512-Z4VY7Rh23yFfSM/F1R9J1ZnzRiJuNDflf8KLE7kryOP+iB46VyfKgw5GwDBOmCXg5n6jBRKMNKeDhwdfxH8oRw==",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
-        "prettier": ">=3.0.0"
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/prop-types": {
@@ -9328,9 +9329,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.8.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.2.tgz",
-      "integrity": "sha512-aJn6wq13/afZp/jT9QZmwEjDqqvSGp1VT5GVg+f/t6/oVyrgXM6BY1h9BRh/O5p3PlUPAe+WuiEZOmb/49RqoQ==",
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
       "peer": true,

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
     "concurrently": "^9.1.2",
     "editorconfig-checker": "^6.0.1",
     "eslint": "^9.24.0",
-    "eslint-config-bananass": "^0.0.7",
+    "eslint-config-bananass": "^0.1.0-canary.2",
     "eslint-plugin-mark": "^0.1.0-canary.1",
     "husky": "^9.1.7",
     "lint-staged": "^15.5.1",
     "markdownlint-cli": "^0.44.0",
     "prettier": "^3.5.3",
-    "prettier-config-bananass": "^0.0.1",
+    "prettier-config-bananass": "^0.1.0-canary.2",
     "textlint": "^14.6.0",
     "textlint-rule-allowed-uris": "^1.1.0"
   }

--- a/sync-client.sh
+++ b/sync-client.sh
@@ -16,8 +16,8 @@ cp configs/.markdownlint.json .
 cp configs/.markdownlintignore .
 cp configs/.nvmrc .
 cp configs/.prettierignore .
-cp configs/.prettierrc.cjs .
 cp configs/.textlintrc.cjs .
 cp configs/VScode.code-workspace .
 cp configs/eslint.config.mjs .
 cp configs/lint-staged.config.mjs .
+cp configs/prettier.config.mjs .


### PR DESCRIPTION
This pull request includes changes to update the configuration files and dependencies for the project. The most important changes involve updating the `prettier` and `eslint` configurations and modifying the `sync-client.sh` script.

Updates to configuration files and dependencies:

* [`configs/.prettierrc.cjs`](diffhunk://#diff-2fe8186baf428cc56a09efc43a22edcd9f5252464f546301c0194a8d42eb5bf9L1): Removed the `prettier-config-bananass` module export.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L28-R34): Updated the `eslint-config-bananass` and `prettier-config-bananass` dependencies to their latest canary versions.

Modifications to `sync-client.sh` script:

* [`sync-client.sh`](diffhunk://#diff-9f218442f37688e98d9dcaf1702d0954aaaabd45dbc04456c4a900bf0f9a24a2L19-R23): Removed the copying of `configs/.prettierrc.cjs` and added the copying of `configs/prettier.config.mjs`.