### PR TITLE
chore(*): add `cooldown` option to `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 7
+      semver-major-days: 45
+      semver-minor-days: 15
+      semver-patch-days: 7
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
@@ -45,6 +50,11 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 7
+      semver-major-days: 45
+      semver-minor-days: 15
+      semver-patch-days: 7
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 2

--- a/configs/.github/dependabot.yml
+++ b/configs/.github/dependabot.yml
@@ -7,6 +7,11 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 7
+      semver-major-days: 45
+      semver-minor-days: 15
+      semver-patch-days: 7
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
@@ -45,6 +50,11 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
+    cooldown:
+      default-days: 7
+      semver-major-days: 45
+      semver-minor-days: 15
+      semver-patch-days: 7
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 2


### PR DESCRIPTION
This pull request introduces a cooldown configuration to the Dependabot settings in both `.github/dependabot.yml` and `configs/.github/dependabot.yml`. The cooldown settings control how frequently Dependabot will create update pull requests, helping to manage update frequency and reduce noise from frequent updates.

Dependabot configuration updates:

* Added a `cooldown` section specifying the number of days between update PRs for different semantic version types (`default-days`, `semver-major-days`, `semver-minor-days`, `semver-patch-days`) in `.github/dependabot.yml. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R14) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R53-R57)
* Added the same `cooldown` configuration in `configs/.github/dependabot.yml` to ensure consistent update behavior across configuration layers. [[1]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R10-R14) [[2]](diffhunk://#diff-dd4fbda47e51f1e35defb9275a9cd9c212ecde0b870cba89ddaaae65c5f3cd28R53-R57)