### PR TITLE
chore(*): update `dependabot`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -51,10 +51,7 @@ updates:
       prefix: 'chore'
       include: 'scope'
     cooldown:
-      default-days: 7
-      semver-major-days: 45
-      semver-minor-days: 15
-      semver-patch-days: 7
+      default-days: 15
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 2

--- a/configs/.github/dependabot.yml
+++ b/configs/.github/dependabot.yml
@@ -51,10 +51,7 @@ updates:
       prefix: 'chore'
       include: 'scope'
     cooldown:
-      default-days: 7
-      semver-major-days: 45
-      semver-minor-days: 15
-      semver-patch-days: 7
+      default-days: 15
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 2


### PR DESCRIPTION
This pull request updates the Dependabot configuration files to simplify cooldown settings for automated dependency updates. The change increases the default cooldown period and removes separate cooldowns for major, minor, and patch updates.

Dependabot configuration changes:

* Increased the `default-days` cooldown value from 7 to 15 and removed the individual cooldown settings for major, minor, and patch updates in `.github/dependabot.yml`.
* Made the same cooldown setting changes in `configs/.github/dependabot.yml`.