### PR TITLE
chore(*): remove `cooldown` in dependabot (its buggy)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,11 +7,6 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
-    cooldown:
-      default-days: 7
-      semver-major-days: 45
-      semver-minor-days: 15
-      semver-patch-days: 7
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
@@ -50,8 +45,6 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
-    cooldown:
-      default-days: 15
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 2

--- a/configs/.github/dependabot.yml
+++ b/configs/.github/dependabot.yml
@@ -7,11 +7,6 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
-    cooldown:
-      default-days: 7
-      semver-major-days: 45
-      semver-minor-days: 15
-      semver-patch-days: 7
     # Specify all directories from the current layer and below recursively, using globstar, for locations of manifest files.
     directories:
       - '**/*'
@@ -50,8 +45,6 @@ updates:
     commit-message:
       prefix: 'chore'
       include: 'scope'
-    cooldown:
-      default-days: 15
     # Workflow files stored in the default location of `.github/workflows`. (You don't need to specify `/.github/workflows` for `directory`. You can use `directory: "/"`.)
     directory: '/'
     open-pull-requests-limit: 2


### PR DESCRIPTION
This pull request removes the `cooldown` configuration from Dependabot settings in both the root and `configs` directories. This change allows Dependabot to create update pull requests without waiting for a cooldown period, making dependency updates more immediate.

Configuration cleanup:

* Removed the `cooldown` section (including `default-days`, `semver-major-days`, `semver-minor-days`, and `semver-patch-days` settings) from the `updates:` block in `.github/dependabot.yml` and `configs/.github/dependabot.yml`.
* Removed the `cooldown` section (with `default-days`) from the workflow update configuration in both `.github/dependabot.yml` and `configs/.github/dependabot.yml`.